### PR TITLE
Fix race-condition during multi-byte reads

### DIFF
--- a/adxl345/src/main/java/com/cacaosd/adxl345/ADXL345.java
+++ b/adxl345/src/main/java/com/cacaosd/adxl345/ADXL345.java
@@ -208,24 +208,15 @@ public class ADXL345 implements AutoCloseable {
     }
 
     public int getAccelerationX() throws IOException {
-        int lsb = this.mDevice.readRegByte(ADXL345_RA_DATAX0) & 0xff;
-        int msb = this.mDevice.readRegByte(ADXL345_RA_DATAX1);
-
-        return (msb << 8 | lsb);
+        return this.mDevice.readRegWord(ADXL345_RA_DATAX0);
     }
 
     public int getAccelerationY() throws IOException {
-        int lsb = this.mDevice.readRegByte(ADXL345_RA_DATAY0) & 0xff;
-        int msb = this.mDevice.readRegByte(ADXL345_RA_DATAY1);
-
-        return (msb << 8 | lsb);
+        return this.mDevice.readRegWord(ADXL345_RA_DATAY0);
     }
 
     public int getAccelerationZ() throws IOException {
-        int lsb = this.mDevice.readRegByte(ADXL345_RA_DATAZ0) & 0xff;
-        int msb = this.mDevice.readRegByte(ADXL345_RA_DATAZ1);
-
-        return (msb << 8 | lsb);
+        return this.mDevice.readRegWord(ADXL345_RA_DATAZ0);
     }
 
     public float[] getAccelerations() throws IOException {


### PR DESCRIPTION
Bad readings can occur when multi-byte reads happen when the lsb is close to under/overflow, e.g. when the value is teetering between 255 and 256, if the change happens between the two readings, msb and lsb can be out-of-sync, so we get 0 instead of 256.

This change fixes the above, by reading both bytes in the same call.